### PR TITLE
Updating the desktop upgrade ID

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "2",
+    "id": "desktop_upgrade_v4.6",
     "conditions": {
       "audience": "all",
       "clientType": "desktop",


### PR DESCRIPTION
Updating the desktop upgrade ID so it will trigger again for users that missed the notice the first time. Doing this in an effort to get more users upgraded who may have missed the notice the first time