### PR TITLE
v5.35 Upgrade Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -72,5 +72,24 @@
         "actionParam": "https://mattermost.com/blog/custom-statuses/"
       }
     }
+  },
+  {
+    "id": "upgrade note",
+    "conditions": {
+      "audience": "sysadmin",
+      "clientType": "all",
+      "instanceType": "onprem",
+      "serverVersion": [">5.30"],
+      "displayDate": ">= 2021-05-10T00:00:00Z"
+    },
+    "localizedMessages": {
+      "en": {
+        "title": "Important Upgrade Note for Upcoming v5.35.0 Release",
+        "description": "Due to the introduction of backend database architecture required for upcoming new features, Shared Channels and Collapsed Reply Threads, the performance of the migration process for the v5.35 release (May 16, 2021) has been noticeably affected.",
+        "image": "https://raw.githubusercontent.com/mattermost/notices/release/images/server_upgrade.png",
+        "actionText": "Learn more",
+        "actionParam": "https://docs.mattermost.com/administration/important-upgrade-notes.html/"
+      }
+    }
   }
 ]


### PR DESCRIPTION
I drafted a notice for the v5.35 upgrade note https://community-release.mattermost.com/private-core/pl/7ayuonfxnbfrxei6g9zr5npyxa.

Wasn't sure if we want to do it like this, so please provide any feedback.

There would be now 5 notices in total. Also, not sure if we'd want to combine this somehow with the upcoming notice for v5.35 release.