### PR TITLE
ci: use github action to test PRs and gitlab for internal releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [ pull_request ]
+
+jobs:
+  analyze:
+    name: validate-json
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - run: npm install -g ajv-cli
+    - run: ajv validate -s notices.schema.json -d notices.json | tee ajv-out.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,19 @@
 stages:
   - verify-json
   - deploy
+
 validate-json:
   image: node:lts-alpine3.11
   stage: verify-json
   script:
     - npm install -g ajv-cli
     - ajv validate -s notices.schema.json -d notices.json | tee ajv-out.txt
+  only:
+    refs:
+      - master
+      - release
+      - e2etest
+
 pre-release:
   image: amazon/aws-cli
   stage: deploy
@@ -24,6 +31,7 @@ pre-release:
   only:
     refs:
       - master
+
 release:
   image: amazon/aws-cli
   stage: deploy
@@ -40,6 +48,7 @@ release:
   only:
     refs:
       - release
+
 e2e:
   image: amazon/aws-cli
   stage: deploy


### PR DESCRIPTION
#### Summary
ci: use github action to test PRs and gitlab for internal releases

using GitLab for PR testing can take more time to get feedback.
this project is simple and we can get very fast feedback on PRs using Github actions. GitLab will be used for release and internal things for the master/release/e2etest branches as previously.

the only change is to use github actions for PR

#### Ticket Link
N/A
