### PR TITLE
FTUE survey notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -110,5 +110,23 @@
         "actionParam": "https://mattermost.com/blog/collapsed-reply-threads-beta/"
       }
     }
+  },
+  {
+    "id": "ftue-survey",
+    "conditions": {
+      "audience": "sysadmin",
+      "clientType": "all",
+      "numberOfUsers": "1",
+      "numberOfPosts": "3"
+    },
+    "localizedMessages": {
+      "en": {
+        "title": "Share your first impressions and get a $50 gift card",
+        "description": "Thank you for trying Mattermost. We’d love to chat with you and see how you like it so far! For 30 minutes of your time, we will gift you a $50 Amazon gift card (or other if not available in your region). If interested, simply schedule 30 minutes using the link below.",
+        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/Feedback.png",
+        "actionText": "Schedule",
+        "actionParam": "https://calendly.com/d/ycdh-gmkr/mattermost-first-impressions"
+      }
+    }
   }
 ]


### PR DESCRIPTION
Rebasing the PR submitted by Katie here: https://github.com/mattermost/notices/pull/219

When testing this we should start up a new server and see what happens when the admins post count reaches > 3. ie does the notice pop up immediately or does it require a refresh or websocket reconnection before the notice appears? If it doesn't show until refresh or reconnection then maybe we can lower the post count to 1 or 2. The goal in my mind is to make sure we aren't interrupting the onboarding flow. cc// @ogi-m 
