### PR TITLE
CRT GA notices

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -66,7 +66,7 @@
     },
     "localizedMessages": {
       "en": {
-        "title": "Collapsed Reply Threads are here, now in general availability!",
+        "title": "Now enable Collapsed Reply Threads by default for all users!",
         "description": "You can now enable Collapsed Reply Threads by default for all users in **System Console** > **Posts** > **Collapsed Reply Threads**.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/crt.gif",
         "actionText": "Learn more",

--- a/notices.json
+++ b/notices.json
@@ -42,7 +42,6 @@
       "audience": "sysadmin",
       "clientType": "all",
       "serverVersion": [">=7.0"],
-      "displayDate": ">= 2022-06-19T00:00:00Z",
       "instanceType": "onprem",
       "serverConfig": { "ServiceSettings.CollapsedThreads": "disabled" }
     },
@@ -62,7 +61,6 @@
       "audience": "sysadmin",
       "clientType": "all",
       "serverVersion": [">=7.0"],
-      "displayDate": ">= 2022-06-19T00:00:00Z",
       "instanceType": "onprem",
       "serverConfig": { "ServiceSettings.CollapsedThreads": "default_off" }
     },

--- a/notices.json
+++ b/notices.json
@@ -42,7 +42,7 @@
       "audience": "sysadmin",
       "clientType": "all",
       "serverVersion": [">=7.0"],
-      "instanceType": "onprem",
+      "displayDate": ">= 2022-06-16T00:00:00Z",
       "serverConfig": { "ServiceSettings.CollapsedThreads": "disabled" }
     },
     "localizedMessages": {
@@ -61,7 +61,7 @@
       "audience": "sysadmin",
       "clientType": "all",
       "serverVersion": [">=7.0"],
-      "instanceType": "onprem",
+      "displayDate": ">= 2022-06-16T00:00:00Z",
       "serverConfig": { "ServiceSettings.CollapsedThreads": "default_off" }
     },
     "localizedMessages": {

--- a/notices.json
+++ b/notices.json
@@ -37,40 +37,78 @@
     }
   },
   {
-    "id": "crt-beta-user",
-    "conditions": {
-      "audience": "all",
-      "clientType": "all",
-      "serverVersion": [">5.36"],
-      "displayDate": ">= 2021-07-19T00:00:00Z",
-      "serverConfig": { "ServiceSettings.CollapsedThreads": "default_off" }
-    },
-    "localizedMessages": {
-      "en": {
-        "title": "Collapsed Reply Threads are here, get early access to the beta",
-        "description": "You can now enable an early beta of Collapsed Reply Threads in **Account Settings** > **Display** > **Collapsed Reply Threads (Beta)**\n\nPlease [review the list of known issues](https://docs.mattermost.com/messaging/organizing-conversations.html#known-issues) as we work towards stabilizing the feature.",
-        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/crt.gif",
-        "actionText": "Learn more",
-        "actionParam": "https://mattermost.com/blog/collapsed-reply-threads-beta/"
-      }
-    }
-  },
-  {
-    "id": "crt-beta-admin",
+    "id": "crt-admin-disabled",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": [">5.36"],
-      "displayDate": ">= 2021-07-19T00:00:00Z",
+      "serverVersion": [">=7.0"],
+      "displayDate": ">= 2022-06-19T00:00:00Z",
       "serverConfig": { "ServiceSettings.CollapsedThreads": "disabled" }
     },
     "localizedMessages": {
       "en": {
-        "title": "Collapsed Reply Threads are here, get early access to the beta",
-        "description": "You can now enable an early beta of Collapsed Reply Threads for this workspace in **System Console** > **Experimental** > **Collapsed Reply Threads (Beta)**\n\nPlease [review the list of known issues](https://docs.mattermost.com/messaging/organizing-conversations.html#known-issues) as we work towards stabilizing the feature.",
+        "title": "Collapsed Reply Threads are here, now in general availability!",
+        "description": "Experience a better way to communicate in threads that keeps your channels and conversations organized.\n\nYou can now enable Collapsed Reply Threads by default for all users in **System Console** > **Posts** > **Collapsed Reply Threads**.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/crt.gif",
         "actionText": "Learn more",
-        "actionParam": "https://mattermost.com/blog/collapsed-reply-threads-beta/"
+        "actionParam": "https://support.mattermost.com/hc/en-us/articles/6880701948564"
+      }
+    }
+  },
+  {
+    "id": "crt-admin-default_off",
+    "conditions": {
+      "audience": "sysadmin",
+      "clientType": "all",
+      "serverVersion": [">=7.0"],
+      "displayDate": ">= 2022-06-19T00:00:00Z",
+      "serverConfig": { "ServiceSettings.CollapsedThreads": "default_off" }
+    },
+    "localizedMessages": {
+      "en": {
+        "title": "Collapsed Reply Threads are here, now in general availability!",
+        "description": "You can now enable Collapsed Reply Threads by default for all users in **System Console** > **Posts** > **Collapsed Reply Threads**.",
+        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/crt.gif",
+        "actionText": "Learn more",
+        "actionParam": "https://support.mattermost.com/hc/en-us/articles/6880701948564"
+      }
+    }
+  },
+  {
+    "id": "crt-user-default-on",
+    "conditions": {
+      "audience": "all",
+      "clientType": "all",
+      "serverVersion": [">=7.0"],
+      "displayDate": ">= 2022-06-16T00:00:00Z",
+      "serverConfig": { "ServiceSettings.CollapsedThreads": "default_on" }
+    },
+    "localizedMessages": {
+      "en": {
+        "title": "Experience a better way to communicate in threads",
+        "description": "Welcome to Collapsed Reply Threads! You can now find, follow, and resume conversations more easily, and keep discussion threads focused.\n\nYou can always disable it in **Settings** > **Display** > **Collapsed Reply Threads**",
+        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/crt.gif",
+        "actionText": "Learn more",
+        "actionParam": "https://docs.mattermost.com/channels/organize-conversations.html"
+      }
+    }
+  },
+  {
+    "id": "crt-user-always-on",
+    "conditions": {
+      "audience": "all",
+      "clientType": "all",
+      "serverVersion": [">=7.0"],
+      "displayDate": ">= 2022-06-16T00:00:00Z",
+      "serverConfig": { "ServiceSettings.CollapsedThreads": "always_on" }
+    },
+    "localizedMessages": {
+      "en": {
+        "title": "Experience a better way to communicate in threads",
+        "description": "Welcome to Collapsed Reply Threads! You can now find, follow, and resume conversations more easily, and keep discussion threads focused.",
+        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/crt.gif",
+        "actionText": "Learn more",
+        "actionParam": "https://docs.mattermost.com/channels/organize-conversations.html"
       }
     }
   },

--- a/notices.json
+++ b/notices.json
@@ -43,6 +43,7 @@
       "clientType": "all",
       "serverVersion": [">=7.0"],
       "displayDate": ">= 2022-06-19T00:00:00Z",
+      "instanceType": "onprem",
       "serverConfig": { "ServiceSettings.CollapsedThreads": "disabled" }
     },
     "localizedMessages": {
@@ -62,6 +63,7 @@
       "clientType": "all",
       "serverVersion": [">=7.0"],
       "displayDate": ">= 2022-06-19T00:00:00Z",
+      "instanceType": "onprem",
       "serverConfig": { "ServiceSettings.CollapsedThreads": "default_off" }
     },
     "localizedMessages": {


### PR DESCRIPTION
Adding 4 new notices for CRT GA:

1. On-prem + cloud instances set to "Disabled": Encourage **admins** to enable CRT
2. On-prem + cloud instances set to "Default_off": encourage **admins** to enable CRT by default
3. On-prem + Cloud users in servers set to "default_on": Introduce all users to CRT and let them know they can disable it.
4. On-prem + Cloud users in servers set to "always_on": Introduce all users to CRT