### PR TITLE
Desktop v5.4 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -1,16 +1,16 @@
 [
   {
-    "id": "desktop_upgrade_v5.2",
+    "id": "desktop_upgrade_v5.4",
     "conditions": {
       "audience": "all",
       "clientType": "desktop",
-      "desktopVersion": ["<5.2"],
+      "desktopVersion": ["<5.4"],
       "serverVersion": [">=6.0"]
     },
     "localizedMessages": {
       "en": {
         "title": "New desktop version available",
-        "description": "Desktop App v5.2 includes a downloads dropdown for managing downloads and an improved onboarding screen for adding new servers. See [the changelog](https://docs.mattermost.com/install/desktop-app-changelog.html) for more details.",
+        "description": "Desktop App v5.4 includes an improved URL validation and an improved add/edit server experience. See [the changelog](https://docs.mattermost.com/install/desktop-app-changelog.html) for more details.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/desktop_v5.0.gif",
         "actionText": "Download",
         "actionParam": "https://mattermost.com/download?inapp-notice=true#mattermostApps"


### PR DESCRIPTION
#### Summary
Desktop app v5.4 in-product notice.

#### Screenshots of the modals or screens in all target clients (required)
 - Screenshot of the desktop app notice: https://raw.githubusercontent.com/mattermost/notices/master/images/desktop_upgrade.png

#### Test environment (required)
 - Latest server version (7.10.3) 
 - Desktop app v5.3 and v5.4

#### Test steps and expectation (required)
 - Have a Desktop app version that is older than v5.4.0 (e.g. v5.3.0). See that the Notice appears.
 - Have a Desktop app version v5.4.0. The Notice should not appear.