### PR TITLE
v8.1 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -34,21 +34,21 @@
     }
   },
   {
-    "id": "server_upgrade_v8.0",
+    "id": "server_upgrade_v8.1",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<8.0"],
+      "serverVersion": ["<8.1"],
       "instanceType": "onprem",
-      "displayDate": ">= 2023-07-17T00:00:00Z"
+      "displayDate": ">= 2023-08-28T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 8.0 is here!",
-        "description": "Mattermost v8.0 is focused on increasing your team’s operational efficiency, expanding our ecosystem, and improving our platform. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 8.1 is here!",
+        "description": "Mattermost v8.1 is the newest Extended Support Release. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
-        "actionParam": "https://mattermost.com/blog/mattermost-v8-0-is-now-available/?utm_source=inapp-self-hosted&utm_medium=popup&utm_campaign=mattermost-7-5-&utm_id=nov-notifications&utm_content=7-5-available"
+        "actionParam": "https://docs.mattermost.com/install/self-managed-changelog.html/?utm_source=inapp-self-hosted&utm_medium=popup&utm_campaign=mattermost-7-5-&utm_id=nov-notifications&utm_content=7-5-available"
       }
     }
   },


### PR DESCRIPTION
#### Summary
 - In-product notice for v8.1 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/350/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R48.

#### Test environment (required)
 - [x] Server versions - v8.0 and v8.1

#### Test steps and expectation (required)
 - Spin up a v8.0 server - the notice should appear.
 - Spin up a v8.1 server - the notice should not appear.
