### PR TITLE
Testing - Added another version to the list

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -4,7 +4,7 @@
     "conditions": {
       "audience": "sysadmin",
       "instanceType": "onprem",
-      "serverVersion": ["7.9-7.10"]
+      "serverVersion": ["7.9-7.10", "8.1.0"]
     },
     "localizedMessages": {
       "en": {


### PR DESCRIPTION
#### Summary
Something seems to be failing that notice is not shown. Troubleshooting the server version list. Added a second one to the list now as one worked as expected. Original notice PR: https://github.com/mattermost/notices/pull/354
