### PR TITLE
Gfycat Deprecation: Removed range with dash

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -21,7 +21,7 @@
     "conditions": {
       "audience": "sysadmin",
       "instanceType": "onprem",
-      "serverVersion": ["7.9-7.11"]
+      "serverVersion": [">= 7.9 <= 7.10"]
     },
     "localizedMessages": {
       "en": {
@@ -38,7 +38,7 @@
     "conditions": {
       "audience": "sysadmin",
       "instanceType": "onprem",
-      "serverVersion": ["8.0.0-8.0.1"]
+      "serverVersion": [">= 8.0.0 <=8.0.1"]
     },
     "localizedMessages": {
       "en": {


### PR DESCRIPTION
#### Summary

Another change to test the version range without dashes as it seems it's not working for the upper limit version. Original PR: https://github.com/mattermost/notices/pull/354

