### PR TITLE
Update notices.json

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -99,17 +99,17 @@
     }
   },
   {
-    "id": "desktop_upgrade_v5.4",
+    "id": "desktop_upgrade_v5.5",
     "conditions": {
       "audience": "all",
       "clientType": "desktop",
-      "desktopVersion": ["<5.4"],
+      "desktopVersion": ["<5.5"],
       "serverVersion": [">=6.0"]
     },
     "localizedMessages": {
       "en": {
         "title": "New desktop version available",
-        "description": "Desktop App v5.4 includes an improved URL validation and an improved add/edit server experience. See [the changelog](https://docs.mattermost.com/install/desktop-app-changelog.html) for more details.",
+        "description": "Desktop App v5.5 includes various new improvements and bug fixes. See [the changelog](https://docs.mattermost.com/install/desktop-app-changelog.html) for more details.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/desktop_v5.0.gif",
         "actionText": "Download",
         "actionParam": "https://mattermost.com/download?inapp-notice=true#mattermostApps"


### PR DESCRIPTION
#### Summary
 - In-product notice for Desktop v5.5 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/366/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R131

#### Test environment (required)
 - [x] Server versions - Desktop v5.4 and v5.5

#### Test steps and expectation (required)
 - On v5.4 Desktop app - the notice should appear.
 - On v5.5 Desktop app- the notice should not appear.