### PR TITLE
v9.2 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -117,21 +117,21 @@
     }
   },
   {
-    "id": "server_upgrade_v9.1",
+    "id": "server_upgrade_v9.2",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<9.1"],
+      "serverVersion": ["<9.2"],
       "instanceType": "onprem",
-      "displayDate": ">= 2023-10-19T00:00:00Z"
+      "displayDate": ">= 2023-11-20T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 9.1 is here!",
-        "description": "Mattermost v9.1 includes the [ability to convert a Group Message (GM) to a private channel](https://docs.mattermost.com/collaborate/convert-group-messages.html), and [Group Messages by default will now push out a notification per new post](https://docs.mattermost.com/collaborate/channel-types.html#group-messages). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 9.2 is here!",
+        "description": "Mattermost v9.2 includes various new improvements and bug fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
-        "actionParam": "https://mattermost.com/blog/mattermost-v9-1-is-now-available/?utm_source=inapp-self-hosted&utm_medium=popup&utm_campaign=mattermost-7-5-&utm_id=nov-notifications&utm_content=7-5-available"
+        "actionParam": "https://docs.mattermost.com/deploy/mattermost-changelog.html/?utm_source=inapp-self-hosted&utm_medium=popup&utm_campaign=mattermost-7-5-&utm_id=nov-notifications&utm_content=7-5-available"
       }
     }
   },


### PR DESCRIPTION
#### Summary
 - In-product notice for v9.2 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/380/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R131

#### Test environment (required)
 - [x] Server versions - v9.1 and v9.2

#### Test steps and expectation (required)
 - Spin up a v9.1 server - the notice should appear.
 - Spin up a v9.2 server - the notice should not appear.