### PR TITLE
v9.3 and Desktop app v5.6 Notices

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -99,17 +99,17 @@
     }
   },
   {
-    "id": "desktop_upgrade_v5.5",
+    "id": "desktop_upgrade_v5.6",
     "conditions": {
       "audience": "all",
       "clientType": "desktop",
-      "desktopVersion": ["<5.5"],
+      "desktopVersion": ["<5.6"],
       "serverVersion": [">=6.0"]
     },
     "localizedMessages": {
       "en": {
         "title": "New desktop version available",
-        "description": "Desktop App v5.5 includes various new improvements and bug fixes. See [the changelog](https://docs.mattermost.com/install/desktop-app-changelog.html) for more details.",
+        "description": "Desktop App v5.6 includes various new improvements and bug fixes. See [the changelog](https://docs.mattermost.com/install/desktop-app-changelog.html) for more details.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/desktop_v5.0.gif",
         "actionText": "Download",
         "actionParam": "https://mattermost.com/download?inapp-notice=true#mattermostApps"
@@ -117,18 +117,18 @@
     }
   },
   {
-    "id": "server_upgrade_v9.2",
+    "id": "server_upgrade_v9.3",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<9.2"],
+      "serverVersion": ["<9.3"],
       "instanceType": "onprem",
-      "displayDate": ">= 2023-11-20T00:00:00Z"
+      "displayDate": ">= 2024-01-02T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 9.2 is here!",
-        "description": "Mattermost v9.2 includes various new improvements and bug fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 9.3 is here!",
+        "description": "Mattermost v9.3 includes the ability to passively track keywords with highlights without triggering a notification (Professional and Enterprise plans), and various other improvements and bug fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/deploy/mattermost-changelog.html/?utm_source=inapp-self-hosted&utm_medium=popup&utm_campaign=mattermost-7-5-&utm_id=nov-notifications&utm_content=7-5-available"


### PR DESCRIPTION
#### Summary
 - In-product notices for v9.3 and Desktop app v5.6 releases.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/382/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R131
 - The desktop app upgrade image should display https://github.com/mattermost/notices/blob/master/images/desktop_upgrade.png along with the text from https://github.com/mattermost/notices/pull/382/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R112

#### Test environment (required)
 - [x] Server versions - v9.2 and v9.3
 - [x] Desktop app versions - v5.5 and v5.6

#### Test steps and expectation (required)
For the v9.3 server notice:
 - Spin up a v9.2 server - the notice should appear.
 - Spin up a v9.3 server - the notice should not appear.

For the desktop app v5.6 notice:
 - Download a Desktop app v5.5 version - the notice should appear.
 - Download a Desktop app v5.6 version - the notice should not appear.