### PR TITLE
v9.4 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -117,18 +117,18 @@
     }
   },
   {
-    "id": "server_upgrade_v9.3",
+    "id": "server_upgrade_v9.4",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<9.3"],
+      "serverVersion": ["<9.4"],
       "instanceType": "onprem",
-      "displayDate": ">= 2024-01-02T00:00:00Z"
+      "displayDate": ">= 2024-01-18T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 9.3 is here!",
-        "description": "Mattermost v9.3 includes the ability to passively track keywords with highlights without triggering a notification (Professional and Enterprise plans), and various other improvements and bug fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 9.4 is here!",
+        "description": "Mattermost v9.4 includes multiple new improvements and bug fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/deploy/mattermost-changelog.html/?utm_source=inapp-self-hosted&utm_medium=popup&utm_campaign=mattermost-7-5-&utm_id=nov-notifications&utm_content=7-5-available"


### PR DESCRIPTION
#### Summary
 - In-product notice for v9.4 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/384/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R131

#### Test environment (required)
 - [x] Server versions - v9.3 and v9.4

#### Test steps and expectation (required)
 - Spin up a v9.3 server - the notice should appear.
 - Spin up a v9.4 server - the notice should not appear.