### PR TITLE
v9.6 and Desktop app v5.7 Notices

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -99,17 +99,17 @@
     }
   },
   {
-    "id": "desktop_upgrade_v5.6",
+    "id": "desktop_upgrade_v5.7",
     "conditions": {
       "audience": "all",
       "clientType": "desktop",
-      "desktopVersion": ["<5.6"],
+      "desktopVersion": ["<5.7"],
       "serverVersion": [">=6.0"]
     },
     "localizedMessages": {
       "en": {
         "title": "New desktop version available",
-        "description": "Desktop App v5.6 includes various new improvements and bug fixes. See [the changelog](https://docs.mattermost.com/install/desktop-app-changelog.html) for more details.",
+        "description": "Desktop App v5.7 includes various new improvements and bug fixes. See [the changelog](https://docs.mattermost.com/install/desktop-app-changelog.html) for more details.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/desktop_v5.0.gif",
         "actionText": "Download",
         "actionParam": "https://mattermost.com/download?inapp-notice=true#mattermostApps"
@@ -117,18 +117,18 @@
     }
   },
   {
-    "id": "server_upgrade_v9.5",
+    "id": "server_upgrade_v9.6",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<9.5"],
+      "serverVersion": ["<9.6"],
       "instanceType": "onprem",
-      "displayDate": ">= 2024-02-20T00:00:00Z"
+      "displayDate": ">= 2024-03-19T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 9.5 is here!",
-        "description": "Mattermost v9.5 is the newest Extended Support Release and includes multiple new improvements and bug fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 9.6 is here!",
+        "description": "Mattermost v9.6 includes multiple new improvements and bug fixes, including additional user statistics under User Management. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/deploy/mattermost-changelog.html"


### PR DESCRIPTION
#### Summary
 - In-product notices for v9.6 and Desktop app v5.7 releases.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/390/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R131
 - The desktop app upgrade image should display https://github.com/mattermost/notices/blob/master/images/desktop_upgrade.png along with the text from https://github.com/mattermost/notices/pull/390/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R112

#### Test environment (required)
 - [x] Server versions - v9.5 and v9.6
 - [x] Desktop app versions - v5.6 and v5.7

#### Test steps and expectation (required)
For the v9.6 server notice:
 - Spin up a v9.5 server - the notice should appear.
 - Spin up a v9.6 server - the notice should not appear.

For the desktop app v5.7 notice:
 - Download a Desktop app v5.6 version - the notice should appear.
 - Download a Desktop app v5.7 version - the notice should not appear.