### PR TITLE
v9.7 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -117,18 +117,18 @@
     }
   },
   {
-    "id": "server_upgrade_v9.6",
+    "id": "server_upgrade_v9.7",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<9.6"],
+      "serverVersion": ["<9.7"],
       "instanceType": "onprem",
-      "displayDate": ">= 2024-03-19T00:00:00Z"
+      "displayDate": ">= 2024-04-18T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 9.6 is here!",
-        "description": "Mattermost v9.6 includes multiple new improvements and bug fixes, including additional user statistics under User Management. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 9.7 is here!",
+        "description": "Mattermost v9.7 includes multiple new improvements and bug fixes, including [beta of the AI plugin](https://github.com/mattermost/mattermost-plugin-ai). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/deploy/mattermost-changelog.html"


### PR DESCRIPTION
#### Summary
 - In-product notice for v9.7 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/393/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R131

#### Test environment (required)
 - [x] Server versions - v9.6 and v9.7

#### Test steps and expectation (required)
 - Spin up a v9.6 server - the notice should appear.
 - Spin up a v9.7 server - the notice should not appear.