### PR TITLE
Remove boards deprecation notices in cloud

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -67,37 +67,6 @@
       }
     }
   },
- {
-    "id": "boards_deprecations",
-    "conditions": {
-      "audience": "sysadmin",
-      "instanceType": "cloud"
-    },
-    "localizedMessages": {
-      "en": {
-        "title": "Mattermost Boards will be removed on September 28th, 2023",
-        "description": "Mattermost Boards is transitioning to a fully community supported plugin. As a result, Boards will be removed from Mattermost Cloud instances on September 28th, 2023. Click below to learn more about how this impacts your instance and how to prepare.",
-        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/Feedback.png",
-        "actionText": "Learn more",
-        "actionParam": "https://forum.mattermost.com/t/upcoming-product-changes-to-boards-and-various-plugins/16669"
-      }
-    }
-  },
-  {
-    "id": "boards_deprecations_user",
-    "conditions": {
-      "instanceType": "cloud"
-    },
-    "localizedMessages": {
-      "en": {
-        "title": "Mattermost Boards will be removed on September 28th, 2023",
-        "description": "Mattermost Boards is transitioning to a fully community supported plugin. As a result, Boards will be removed from Mattermost Cloud instances on September 28th, 2023. Click below to learn more about how this impacts your instance and how to prepare.",
-        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/Feedback.png",
-        "actionText": "Learn more",
-        "actionParam": "https://forum.mattermost.com/t/upcoming-product-changes-to-boards-and-various-plugins/16669"
-      }
-    }
-  },
   {
     "id": "server_upgrade_v9.8",
     "conditions": {


### PR DESCRIPTION
#### Summary
Remove boards deprecation notices in cloud as all existing workspaces already have received this notice and boards was removed in Cloud Sept 2023. 

#### Jira ticket
https://mattermost.atlassian.net/browse/MM-58691#icft=MM-58691
