### PR TITLE
Remove boards deprecation notices in cloud (#403)

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -68,55 +68,6 @@
     }
   },
   {
-    "id": "boards_deprecations",
-    "conditions": {
-      "audience": "sysadmin",
-      "instanceType": "cloud"
-    },
-    "localizedMessages": {
-      "en": {
-        "title": "Mattermost Boards will be removed on September 28th, 2023",
-        "description": "Mattermost Boards is transitioning to a fully community supported plugin. As a result, Boards will be removed from Mattermost Cloud instances on September 28th, 2023. Click below to learn more about how this impacts your instance and how to prepare.",
-        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/Feedback.png",
-        "actionText": "Learn more",
-        "actionParam": "https://forum.mattermost.com/t/upcoming-product-changes-to-boards-and-various-plugins/16669"
-      }
-    }
-  },
-  {
-    "id": "boards_deprecations_user_2",
-    "conditions": {
-      "instanceType": "cloud"
-    },
-    "localizedMessages": {
-      "en": {
-        "title": "Mattermost Boards will be removed on September 28th, 2023",
-        "description": "Boards will be removed from Mattermost Cloud instances on September 28th, 2023. You must export your boards to CSV files prior to this date. Click below to learn more about how to prepare.",
-        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/Feedback.png",
-        "actionText": "Learn more",
-        "actionParam": "https://forum.mattermost.com/t/upcoming-product-changes-to-boards-and-various-plugins/16669"
-      }
-    }
-  },
-  {
-    "id": "desktop_upgrade_v5.7",
-    "conditions": {
-      "audience": "all",
-      "clientType": "desktop",
-      "desktopVersion": ["<5.7"],
-      "serverVersion": [">=6.0"]
-    },
-    "localizedMessages": {
-      "en": {
-        "title": "New desktop version available",
-        "description": "Desktop App v5.7 includes various new improvements and bug fixes. See [the changelog](https://docs.mattermost.com/install/desktop-app-changelog.html) for more details.",
-        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/desktop_v5.0.gif",
-        "actionText": "Download",
-        "actionParam": "https://mattermost.com/download?inapp-notice=true#mattermostApps"
-      }
-    }
-  },
-  {
     "id": "server_upgrade_v9.8",
     "conditions": {
       "audience": "sysadmin",


### PR DESCRIPTION
#### Summary
Remove Board deprecation notices in release. Cherry pick of https://github.com/mattermost/notices/pull/403

#### Jira ticket
https://mattermost.atlassian.net/browse/MM-58691