### PR TITLE
v9.11 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -68,18 +68,18 @@
     }
   },
   {
-    "id": "server_upgrade_v9.10",
+    "id": "server_upgrade_v9.11",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<9.10"],
+      "serverVersion": ["<9.11"],
       "instanceType": "onprem",
-      "displayDate": ">= 2024-07-18T00:00:00Z"
+      "displayDate": ">= 2024-08-19T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 9.10 is here!",
-        "description": "Mattermost v9.10 includes multiple new improvements and bug fixes, including notification metrics and web app performance improvements. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 9.11 is here!",
+        "description": "Mattermost v9.11 Extended Support Release includes multiple new improvements and bug fixes, including new admin controls for user settings. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/about/mattermost-v9-changelog.html"


### PR DESCRIPTION
#### Summary
 - In-product notice for v9.11 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/408/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R82

#### Test environment (required)
 - [x] Server versions - v9.10 and v9.11

#### Test steps and expectation (required)
 - Spin up a v9.10 server - the notice should appear.
 - Spin up a v9.11 server - the notice should not appear.