### PR TITLE
v10.0 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -68,21 +68,21 @@
     }
   },
   {
-    "id": "server_upgrade_v9.11",
+    "id": "server_upgrade_v10.0",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<9.11"],
+      "serverVersion": ["<10.0"],
       "instanceType": "onprem",
-      "displayDate": ">= 2024-08-19T00:00:00Z"
+      "displayDate": ">= 2024-09-18T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 9.11 is here!",
-        "description": "Mattermost v9.11 Extended Support Release includes multiple new improvements and bug fixes, including new admin controls for user settings. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 10.0 is here!",
+        "description": "Mattermost v10.0 extends Microsoft Teams and M365 platform to accelerate mission-critical workflows in defense, government and vital services at scale. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
-        "actionParam": "https://docs.mattermost.com/about/mattermost-v9-changelog.html"
+        "actionParam": "https://docs.mattermost.com/about/mattermost-v10-changelog.html"
       }
     }
   },


### PR DESCRIPTION
#### Summary
 - In-product notice for v10.0 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/413/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R82

#### Test environment (required)
 - [x] Server versions - v9.11 and v10.0

#### Test steps and expectation (required)
 - Spin up a v9.11 server - the notice should appear.
 - Spin up a v10.0 server - the notice should not appear.