### PR TITLE
v10.3 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -68,18 +68,18 @@
     }
   },
   {
-    "id": "server_upgrade_v10.2",
+    "id": "server_upgrade_v10.3",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<10.2"],
+      "serverVersion": ["<10.3"],
       "instanceType": "onprem",
-      "displayDate": ">= 2024-11-18T00:00:00Z"
+      "displayDate": ">= 2024-12-18T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 10.2 is here!",
-        "description": "Mattermost v10.2 includes multiple new improvements and bug fixes, including [Connected Workspaces](https://docs.mattermost.com/onboard/connected-workspaces.html). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 10.3 is here!",
+        "description": "Mattermost v10.3 includes multiple new improvements and bug fixes, including [Scheduled Messages](https://docs.mattermost.com/collaborate/schedule-messages.html). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/about/mattermost-v10-changelog.html"


### PR DESCRIPTION
#### Summary
 - In-product notice for v10.3 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/421/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R82

#### Test environment (required)
 - [x] Server versions - v10.2 and v10.3

#### Test steps and expectation (required)
 - Spin up a v10.2 server - the notice should appear.
 - Spin up a v10.3 server - the notice should not appear.