### PR TITLE
v10.7 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -68,18 +68,18 @@
     }
   },
   {
-    "id": "server_upgrade_v10.6",
+    "id": "server_upgrade_v10.7",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<10.6"],
+      "serverVersion": ["<10.7"],
       "instanceType": "onprem",
-      "displayDate": ">= 2025-03-17T00:00:00Z"
+      "displayDate": ">= 2025-04-17T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 10.6 is here!",
-        "description": "Mattermost v10.6 includes multiple new quality of life improvements as well as PostgreSQL performance enhancements. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 10.7 is here!",
+        "description": "Mattermost v10.7 includes multiple new quality of life improvements. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/about/mattermost-v10-changelog.html"


### PR DESCRIPTION
#### Summary
 - In-product notice for v10.7 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/430/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R82

#### Test environment (required)
 - [x] Server versions - v10.6 and v10.7

#### Test steps and expectation (required)
 - Spin up a v10.6 server - the notice should appear.
 - Spin up a v10.7 server - the notice should not appear.