### PR TITLE
v10.12 Notice

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -68,18 +68,18 @@
     }
   },
   {
-    "id": "server_upgrade_v10.11",
+    "id": "server_upgrade_v10.12",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<10.11"],
+      "serverVersion": ["<10.12"],
       "instanceType": "onprem",
-      "displayDate": ">= 2025-08-18T00:00:00Z"
+      "displayDate": ">= 2025-09-18T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 10.11 is here!",
-        "description": "Mattermost v10.11 Extended Support Release contains multiple new quality of life improvements, including server support for [Playbooks on mobile](https://docs.mattermost.com/end-user-guide/workflow-automation.html#access). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 10.12 is here!",
+        "description": "Mattermost v10.12 release contains multiple new quality of life improvements. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/product-overview/mattermost-v10-changelog.html"


### PR DESCRIPTION
#### Summary
 - In-product notice for v10.12 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/443/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R82.

#### Test environment (required)
 - [x] Server versions - v10.12 and v10.11

#### Test steps and expectation (required)
 - Spin up a v10.11 server - the notice should appear.
 - Spin up a v10.12 server - the notice should not appear.