### PR TITLE
v10.5.11 and v10.11.3 dot release notices

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -87,6 +87,44 @@
     }
   },
   {
+    "id": "patch_upgrade",
+    "conditions": {
+      "audience": "sysadmin",
+      "clientType": "all",
+      "serverVersion": [">= 10.5.0 <=10.5.10"],
+      "instanceType": "onprem",
+      "displayDate": ">= 2025-09-17T00:00:00Z"
+    },
+    "localizedMessages": {
+      "en": {
+        "title": "Mattermost 10.5.11 is now available",
+        "description": "Mattermost v10.5.11 Extended Support Release contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) is recommended.",
+        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
+        "actionText": "Learn more",
+        "actionParam": "https://docs.mattermost.com/about/mattermost-v10-changelog.html"
+      }
+    }
+  },
+  {
+    "id": "patch_upgrade2",
+    "conditions": {
+      "audience": "sysadmin",
+      "clientType": "all",
+      "serverVersion": [">= 10.11.0 <=10.11.2"],
+      "instanceType": "onprem",
+      "displayDate": ">= 2025-09-17T00:00:00Z"
+    },
+    "localizedMessages": {
+      "en": {
+        "title": "Mattermost 10.11.3 is now available",
+        "description": "Mattermost v10.11.3 Extended Support Release contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) is recommended.",
+        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
+        "actionText": "Learn more",
+        "actionParam": "https://docs.mattermost.com/about/mattermost-v10-changelog.html"
+      }
+    }
+  },
+  {
     "id": "crt-admin-disabled",
     "conditions": {
       "audience": "sysadmin",


### PR DESCRIPTION
#### Summary
 - In-product notice for v10.5.11 and v10.11.3 dot releases.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/439/files#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R120

#### Test environment (required)
 - [x] Server versions - any version from v10.5.0 to v5.10.10; a server version older or newer than v10.5.x

#### Test steps and expectation (required)
 - Spin up a server with a version between v10.5.0 to v5.10.10- the notice should appear only for these versions. 
 - Spin up a server with a version other than v10.5.x - the notice should not appear for any other versions.