### PR TITLE
Notices for two feature deprecations in v11

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -222,7 +222,7 @@
     "conditions": {
       "audience": "sysadmin",
       "serverVersion": ["<11.0"],
-      "serverConfig": { "ExperimentalSettings.ClientSideCertEnable": "true" }
+      "serverConfig": { "ExperimentalSettings.ClientSideCertEnable": true }
     },
     "localizedMessages": {
       "en": {


### PR DESCRIPTION
#### Summary
 - In-product notices for two feature deprecations in v11.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the relevant texts.

#### Test environment (required)
 - [x] Server versions - any version below v11.0.
 - [x] For the first notice - "EnableSearching", "DisableDatabaseSearch", "EnableIndexing" and "IndexDir" configuration settings should be set to "true".
 - [x] For the second notice - "ExperimentalSettings.ClientSideCertEnable" configuration setting should be set to "true".

#### Test steps and expectation (required)
 - The notices should appear when spinning up a test environment with the test environment described above. See more on how to test notices at https://github.com/mattermost/notices?tab=readme-ov-file#how-to-test-notices-via-cloud-plugin.