### PR TITLE
Test notice 11.5

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -87,18 +87,18 @@
     }
     },
     {
-    "id": "server_upgrade_v11.4",
+    "id": "server_upgrade_v11.5",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<11.4"],
+      "serverVersion": ["<11.5"],
       "instanceType": "onprem",
-      "displayDate": ">= 2026-02-17T00:00:00Z"
+      "displayDate": ">= 2026-03-18T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 11.4 is here!",
-        "description": "Mattermost v11.4 release contains multiple new quality of life improvements. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 11.5 is here!",
+        "description": "Mattermost v11.5 release contains multiple new quality of life improvements, including [CJK Database Search](http://docs.mattermost.com/administration-guide/configure/enabling-chinese-japanese-korean-search.html), [AI Channel Summarization](http://docs.mattermost.com/end-user-guide/agents.html), [Agents Web Search](http://docs.mattermost.com/administration-guide/configure/agents-admin-guide.html), User Authoritative Source, and [Channel Auto-Translation](https://docs.mattermost.com/end-user-guide/collaborate/autotranslate-messages.html). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/product-overview/mattermost-v11-changelog.html"
@@ -129,14 +129,14 @@
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": [">= 10.11.0 <=10.11.10"],
+      "serverVersion": [">= 10.11.0 <=10.11.12"],
       "instanceType": "onprem",
-      "displayDate": ">= 2026-02-17T00:00:00Z"
+      "displayDate": ">= 2026-03-18T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 10.11.11 is now available",
-        "description": "Mattermost v10.11.11 Extended Support Release contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended.",
+        "title": "Mattermost 10.11.13 is now available",
+        "description": "Mattermost v10.11.13 Extended Support Release contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/about/mattermost-v10-changelog.html"


### PR DESCRIPTION
Release PR: https://github.com/mattermost/notices/pull/472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated in-app notices for server versions 11.5 and 10.11.13
  * Adjusted notice display dates and version conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->