### PR TITLE
v11.6 & v10.11.15 Notices

### DIFF
--- a/notices.json
+++ b/notices.json
@@ -110,14 +110,14 @@
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": [">= 10.11.0 <=10.11.12"],
+      "serverVersion": [">= 10.11.0 <=10.11.13"],
       "instanceType": "onprem",
-      "displayDate": ">= 2026-03-16T00:00:00Z"
+      "displayDate": ">= 2026-04-15T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 10.11.13 is now available",
-        "description": "Mattermost v10.11.13 Extended Support Release contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended.",
+        "title": "Mattermost 10.11.14 is now available",
+        "description": "Mattermost v10.11.14 Extended Support Release contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/about/mattermost-v10-changelog.html"

--- a/notices.json
+++ b/notices.json
@@ -110,14 +110,14 @@
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": [">= 10.11.0 <=10.11.13"],
+      "serverVersion": [">= 10.11.0 <=10.11.14"],
       "instanceType": "onprem",
-      "displayDate": ">= 2026-04-15T00:00:00Z"
+      "displayDate": ">= 2026-04-22T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 10.11.14 is now available",
-        "description": "Mattermost v10.11.14 Extended Support Release contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended.",
+        "title": "Mattermost 10.11.15 is now available",
+        "description": "Mattermost v10.11.15 Extended Support Release contains medium to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/about/mattermost-v10-changelog.html"

--- a/notices.json
+++ b/notices.json
@@ -68,18 +68,18 @@
     }
   },
   {
-    "id": "server_upgrade_v11.5",
+    "id": "server_upgrade_v11.6",
     "conditions": {
       "audience": "sysadmin",
       "clientType": "all",
-      "serverVersion": ["<11.5"],
+      "serverVersion": ["<11.6"],
       "instanceType": "onprem",
-      "displayDate": ">= 2026-03-16T00:00:00Z"
+      "displayDate": ">= 2026-04-16T00:00:00Z"
     },
     "localizedMessages": {
       "en": {
-        "title": "Mattermost 11.5 is here!",
-        "description": "Mattermost v11.5 release contains multiple new quality of life improvements, including [CJK Database Search](https://docs.mattermost.com/administration-guide/configure/enabling-chinese-japanese-korean-search.html), [AI Channel Summarization](https://docs.mattermost.com/end-user-guide/agents.html), [Agents Web Search](https://docs.mattermost.com/administration-guide/configure/agents-admin-guide.html), User Authoritative Source, and [Channel Auto-Translation](https://docs.mattermost.com/end-user-guide/collaborate/autotranslate-messages.html). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "title": "Mattermost 11.6 is here!",
+        "description": "Mattermost v11.6 release contains multiple new quality of life improvements, including [ID-Based URLs](https://docs.mattermost.com/end-user-guide/collaborate/share-links.html), [Multi-Window Right-Hand Side](https://docs.mattermost.com/end-user-guide/collaborate/search-for-messages.html#search-for-message), and [Single-Channel Guests Reporting](https://docs.mattermost.com/administration-guide/onboard/guest-accounts.html). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/product-overview/mattermost-v11-changelog.html"

--- a/notices.json
+++ b/notices.json
@@ -79,7 +79,7 @@
     "localizedMessages": {
       "en": {
         "title": "Mattermost 11.6 is here!",
-        "description": "Mattermost v11.6 release contains multiple new quality of life improvements, including [ID-Based URLs](https://docs.mattermost.com/end-user-guide/collaborate/share-links.html), [Multi-Window Right-Hand Side](https://docs.mattermost.com/end-user-guide/collaborate/search-for-messages.html#search-for-message), and [Single-Channel Guests Reporting](https://docs.mattermost.com/administration-guide/onboard/guest-accounts.html). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "description": "Mattermost v11.6 release contains multiple new quality of life improvements, including [ID-Based URLs](https://docs.mattermost.com/end-user-guide/collaborate/share-links.html), [Multi-Window Right-Hand Side Search](https://docs.mattermost.com/end-user-guide/collaborate/search-for-messages.html#search-for-message), and [Single-Channel Guests Reporting](https://docs.mattermost.com/administration-guide/onboard/guest-accounts.html). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/product-overview/mattermost-v11-changelog.html"

--- a/notices.json
+++ b/notices.json
@@ -79,7 +79,7 @@
     "localizedMessages": {
       "en": {
         "title": "Mattermost 11.6 is here!",
-        "description": "Mattermost v11.6 release contains multiple new quality of life improvements, including [ID-Based URLs](https://docs.mattermost.com/end-user-guide/collaborate/share-links.html), [Multi-Window Right-Hand Side Search](https://docs.mattermost.com/end-user-guide/collaborate/search-for-messages.html#search-for-message), and [Single-Channel Guests Reporting](https://docs.mattermost.com/administration-guide/onboard/guest-accounts.html). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "description": "Mattermost v11.6 release contains multiple new quality of life improvements, including [ID-Based URLs](https://docs.mattermost.com/end-user-guide/collaborate/rename-channels.html), [Multi-Window Right-Hand Side Search](https://docs.mattermost.com/end-user-guide/collaborate/search-for-messages.html#search-for-message), and [Single-Channel Guests Reporting](https://docs.mattermost.com/administration-guide/onboard/guest-accounts.html). [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
         "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
         "actionText": "Learn more",
         "actionParam": "https://docs.mattermost.com/product-overview/mattermost-v11-changelog.html"


### PR DESCRIPTION
#### Summary
 - In-product notice for v11.6 release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/475/changes#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R82.

#### Test environment (required)
 - [x] Server versions - v11.5 and v11.6

#### Test steps and expectation (required)
 - Spin up a v11.5 server - the notice should appear.
 - Spin up a v11.6 server - the notice should not appear.

______________________________

#### Summary
 - In-product notice for v10.11.15 dot release.

#### Screenshots of the modals or screens in all target clients (required)
 - The server upgrade image should display https://github.com/mattermost/notices/blob/master/images/server_upgrade.png along with the text from https://github.com/mattermost/notices/pull/475/changes#diff-11766faeb8c25f77d7dbf8e61fd0e9fc8cd1a08858d6b1f8867715a570bfd9d9R120.

#### Test environment (required)
 - [x] Server versions - any version from v10.11.0 to v10.11.14; a server version older or newer than v10.11.x

#### Test steps and expectation (required)
 - Spin up a server with a version between v10.11.0 to v10.11.14- the notice should appear only for these versions. 
 - Spin up a server with a version other than v10.11.x - the notice should not appear for any other versions.