### PR TITLE
Automate notices testing

### DIFF
--- a/.github/scripts/check-duplicate-ids.js
+++ b/.github/scripts/check-duplicate-ids.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * check-duplicate-ids.js
+ * Scans notices.json for duplicate notice IDs and fails if any are found.
+ * Also warns if an ID added in this PR already existed on the base branch
+ * (which would indicate a merge conflict or accidental re-use).
+ *
+ * Usage: node scripts/check-duplicate-ids.js [--base <git-ref>]
+ */
+ 
+import { spawnSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+ 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+ 
+const args    = process.argv.slice(2);
+const baseIdx = args.indexOf('--base');
+const BASE_REF = baseIdx !== -1 ? args[baseIdx + 1] : 'origin/master';
+ 
+let notices;
+try {
+  notices = JSON.parse(readFileSync(resolve(ROOT, 'notices.json'), 'utf8'));
+} catch (e) {
+  console.error(`❌ Could not parse notices.json: ${e.message}`);
+  process.exit(1);
+}
+ 
+// ── 1. Check for duplicates within the current file ──────────────────────────
+const seen   = new Map(); // id → first occurrence index
+const dupes  = [];
+notices.forEach((notice, idx) => {
+  if (seen.has(notice.id)) {
+    dupes.push({ id: notice.id, first: seen.get(notice.id), second: idx });
+  } else {
+    seen.set(notice.id, idx);
+  }
+});
+ 
+if (dupes.length > 0) {
+  console.error('❌ Duplicate notice IDs found in notices.json:\n');
+  for (const { id, first, second } of dupes) {
+    console.error(`  • "${id}" appears at index ${first} and ${second}`);
+  }
+  process.exit(1);
+}
+ 
+console.log(`✅ No duplicate IDs in notices.json (${notices.length} notices checked).`);
+ 
+// ── 2. Warn if a new ID collides with base branch (should not happen normally) ─
+const baseResult = spawnSync('git', ['show', `${BASE_REF}:notices.json`], {
+  cwd: ROOT, encoding: 'utf8',
+});
+ 
+if (baseResult.status === 0) {
+  let baseNotices = [];
+  try { baseNotices = JSON.parse(baseResult.stdout); } catch { /* ignore */ }
+ 
+  const baseIds  = new Set(baseNotices.map(n => n.id));
+  const current  = new Set(notices.map(n => n.id));
+  const newIds   = [...current].filter(id => !baseIds.has(id));
+ 
+  // Detect IDs that appear in BOTH base and current but were not on base
+  // (shouldn't normally happen after the dedup check above, but catches
+  // concurrent PR merges where two PRs independently add the same ID)
+  const addedOnBase = baseNotices
+    .filter(n => !current.has(n.id))  // removed in this PR
+    .map(n => n.id);
+  const conflicts = newIds.filter(id =>
+    baseNotices.some(n => n.id === id)
+  );
+  if (conflicts.length > 0) {
+    console.warn(`⚠️  ID(s) added in this PR already exist on ${BASE_REF}: ${conflicts.join(', ')}`);
+    console.warn('   This may indicate a merge conflict. Please review.');
+  }
+ 
+  if (newIds.length > 0) {
+    console.log(`ℹ️  New notice ID(s) introduced: ${newIds.join(', ')}`);
+  }
+}
+ 

--- a/.github/scripts/check-duplicate-ids.js
+++ b/.github/scripts/check-duplicate-ids.js
@@ -62,15 +62,9 @@ if (baseResult.status === 0) {
   const current  = new Set(notices.map(n => n.id));
   const newIds   = [...current].filter(id => !baseIds.has(id));
  
-  // Detect IDs that appear in BOTH base and current but were not on base
-  // (shouldn't normally happen after the dedup check above, but catches
-  // concurrent PR merges where two PRs independently add the same ID)
-  const addedOnBase = baseNotices
-    .filter(n => !current.has(n.id))  // removed in this PR
-    .map(n => n.id);
-  const conflicts = newIds.filter(id =>
-    baseNotices.some(n => n.id === id)
-  );
+  // Detect IDs added in this PR that already exist on the base branch
+  // (catches concurrent PR merges where two PRs independently add the same ID)
+  const conflicts = newIds.filter(id => baseIds.has(id));
   if (conflicts.length > 0) {
     console.warn(`⚠️  ID(s) added in this PR already exist on ${BASE_REF}: ${conflicts.join(', ')}`);
     console.warn('   This may indicate a merge conflict. Please review.');
@@ -80,4 +74,3 @@ if (baseResult.status === 0) {
     console.log(`ℹ️  New notice ID(s) introduced: ${newIds.join(', ')}`);
   }
 }
- 

--- a/.github/scripts/check-urls.js
+++ b/.github/scripts/check-urls.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * check-urls.js
+ * Extracts every URL from notices.json (action_param, image, and any URLs in
+ * localizations) and sends a HEAD request to each. Fails if any URL is
+ * unreachable or returns a non-2xx status.
+ *
+ * Usage: node scripts/check-urls.js [--notices path/to/notices.json]
+ */
+ 
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+ 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+ 
+// Allow overriding the notices path via --notices flag (useful for testing against a diff)
+const args = process.argv.slice(2);
+const noticesFlagIdx = args.indexOf('--notices');
+const noticesPath = noticesFlagIdx !== -1
+  ? resolve(args[noticesFlagIdx + 1])
+  : resolve(ROOT, 'notices.json');
+ 
+let notices;
+try {
+  notices = JSON.parse(readFileSync(noticesPath, 'utf8'));
+} catch (e) {
+  console.error(`❌ Could not parse notices.json: ${e.message}`);
+  process.exit(1);
+}
+ 
+/** Collect all URLs from a notice object */
+function extractUrls(notice) {
+  const urls = [];
+  for (const [lang, msg] of Object.entries(notice.localizedMessages ?? {})) {
+    if (msg.actionParam) urls.push({ url: msg.actionParam, field: `localizedMessages.${lang}.actionParam` });
+    if (msg.image)       urls.push({ url: msg.image,       field: `localizedMessages.${lang}.image` });
+    // Scan description for embedded http(s) links
+    const matches = (msg.description ?? '').matchAll(/https?:\/\/[^\s"')>]+/g);
+    for (const m of matches) {
+      urls.push({ url: m[0], field: `localizedMessages.${lang}.description` });
+    }
+  }
+  return urls;
+}
+ 
+/** HEAD request with a 10s timeout, falls back to GET if HEAD returns 405 */
+async function checkUrl(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    let res = await fetch(url, { method: 'HEAD', redirect: 'follow', signal: controller.signal });
+    if (res.status === 405) {
+      // Server doesn't allow HEAD — retry with GET
+      res = await fetch(url, { method: 'GET', redirect: 'follow', signal: controller.signal });
+    }
+    return { ok: res.ok, status: res.status };
+  } catch (e) {
+    return { ok: false, status: null, error: e.message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+ 
+const allUrls = [];
+for (const notice of notices) {
+  for (const entry of extractUrls(notice)) {
+    allUrls.push({ noticeId: notice.id, ...entry });
+  }
+}
+ 
+// Deduplicate by URL to avoid hammering the same endpoint repeatedly
+const seen = new Set();
+const unique = allUrls.filter(({ url }) => {
+  if (seen.has(url)) return false;
+  seen.add(url);
+  return true;
+});
+ 
+if (unique.length === 0) {
+  console.log('ℹ️  No URLs found in notices.json.');
+  process.exit(0);
+}
+ 
+console.log(`🔍 Checking ${unique.length} unique URL(s)…\n`);
+ 
+const results = await Promise.all(
+  unique.map(async (entry) => ({ ...entry, result: await checkUrl(entry.url) }))
+);
+ 
+let failed = false;
+for (const { noticeId, field, url, result } of results) {
+  if (result.ok) {
+    console.log(`  ✅ [${noticeId}] ${field}: ${url} (${result.status})`);
+  } else {
+    const detail = result.error ?? `HTTP ${result.status}`;
+    console.error(`  ❌ [${noticeId}] ${field}: ${url} — ${detail}`);
+    failed = true;
+  }
+}
+ 
+console.log('');
+if (failed) {
+  console.error('❌ One or more URLs are unreachable. Fix them before merging.');
+  process.exit(1);
+} else {
+  console.log('✅ All URLs are reachable.');
+}

--- a/.github/scripts/validate-schema.js
+++ b/.github/scripts/validate-schema.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * validate-schema.js
+ * Validates notices.json against notices.schema.json using ajv.
+ * Exits 1 on any validation error so GitHub Actions marks the check as failed.
+ */
+ 
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+ 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+ 
+const noticesPath = resolve(ROOT, 'notices.json');
+const schemaPath  = resolve(ROOT, 'notices.schema.json');
+ 
+let notices, schema;
+try {
+  notices = JSON.parse(readFileSync(noticesPath, 'utf8'));
+} catch (e) {
+  console.error(`❌ Could not parse notices.json: ${e.message}`);
+  process.exit(1);
+}
+try {
+  schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+} catch (e) {
+  console.error(`❌ Could not parse notices.schema.json: ${e.message}`);
+  process.exit(1);
+}
+ 
+const ajv = new Ajv({ allErrors: true });
+addFormats(ajv);
+const validate = ajv.compile(schema);
+ 
+if (validate(notices)) {
+  console.log(`✅ notices.json is valid (${notices.length} notice(s) checked).`);
+  process.exit(0);
+} else {
+  console.error(`❌ notices.json failed schema validation:\n`);
+  for (const err of validate.errors) {
+    console.error(`  • ${err.instancePath || '(root)'}: ${err.message}`);
+    if (err.params) {
+      console.error(`    params: ${JSON.stringify(err.params)}`);
+    }
+  }
+  process.exit(1);
+}

--- a/.github/scripts/validate-schema.js
+++ b/.github/scripts/validate-schema.js
@@ -35,6 +35,11 @@ const ajv = new Ajv({ allErrors: true });
 addFormats(ajv);
 const validate = ajv.compile(schema);
  
+if (!Array.isArray(notices)) {
+  console.error('❌ notices.json must be a JSON array at the top level.');
+  process.exit(1);
+}
+ 
 if (validate(notices)) {
   console.log(`✅ notices.json is valid (${notices.length} notice(s) checked).`);
   process.exit(0);

--- a/.github/workflows/auto-test-pr.yml
+++ b/.github/workflows/auto-test-pr.yml
@@ -1,0 +1,49 @@
+name: Auto-create test PR on master
+ 
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - release
+ 
+jobs:
+  create-test-pr:
+    name: Mirror PR against master
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+ 
+    steps:
+      - name: Create test PR against master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE:  ${{ github.event.pull_request.title }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_URL:    ${{ github.event.pull_request.html_url }}
+          REPO:      ${{ github.repository }}
+        run: |
+          gh pr create \
+            --repo "$REPO" \
+            --head "$HEAD_BRANCH" \
+            --base master \
+            --title "[Test] $PR_TITLE" \
+            --body "$(cat <<EOF
+          Automated test PR for #$PR_NUMBER.
+ 
+          Merging this into \`master\` will mirror the notices to:
+          https://notices.mattermost.com/pre-release/notices.json
+ 
+          **Original release PR:** $PR_URL
+ 
+          ---
+          To test on a server, run:
+          \`\`\`
+          /cloud upgrade <your-server> \\
+            --env MM_AnnouncementSettings_NoticesURL=https://notices.mattermost.com/pre-release/notices.json \\
+            --env MM_AnnouncementSettings_NoticesFetchFrequency=60
+          \`\`\`
+          EOF
+          )"
+          

--- a/.github/workflows/auto-test-pr.yml
+++ b/.github/workflows/auto-test-pr.yml
@@ -20,7 +20,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE:  ${{ github.event.pull_request.title }}
-          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.label }}
           PR_URL:    ${{ github.event.pull_request.html_url }}
           REPO:      ${{ github.repository }}
         run: |
@@ -46,4 +46,3 @@ jobs:
           \`\`\`
           EOF
           )"
-          

--- a/.github/workflows/validate-notices.yml
+++ b/.github/workflows/validate-notices.yml
@@ -1,0 +1,46 @@
+name: Validate Notices PR
+ 
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'notices.json'
+      - 'notices.schema.json'
+      - 'scripts/**'
+ 
+jobs:
+  validate:
+    name: Validate notices.json
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+ 
+    steps:
+      - name: Checkout PR branch (with base branch history for diffing)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # Full history so scripts can diff against base
+ 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+ 
+      - name: Install dependencies
+        run: npm install ajv ajv-formats
+ 
+      # ── 1. JSON schema validation ────────────────────────────────────────────
+      - name: Schema validation
+        run: node scripts/validate-schema.js
+ 
+      # ── 2. Duplicate ID check ────────────────────────────────────────────────
+      - name: Duplicate ID check
+        run: node scripts/check-duplicate-ids.js --base origin/master
+ 
+      # ── 3. URL reachability ──────────────────────────────────────────────────
+      - name: URL reachability check
+        run: node scripts/check-urls.js
+        

--- a/.github/workflows/validate-notices.yml
+++ b/.github/workflows/validate-notices.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          # No npm cache — there is no package-lock.json in this repo
  
       - name: Install dependencies
-        run: npm install ajv ajv-formats
+        run: npm install --no-save ajv@8.17.1 ajv-formats@3.0.1
  
       # ── 1. JSON schema validation ────────────────────────────────────────────
       - name: Schema validation
@@ -43,4 +43,3 @@ jobs:
       # ── 3. URL reachability ──────────────────────────────────────────────────
       - name: URL reachability check
         run: node scripts/check-urls.js
-        


### PR DESCRIPTION
Adding GitHub Actions automation to reduce manual steps in the in-product notices testing workflow.
Spec doc: https://mattermost.atlassian.net/wiki/spaces/Security/pages/4550393860/Automation+-+In-Product+Notices+Testing

________________________

1. validate-notices.yml — runs on every PR targeting master when ``notices.json`` changes. It performs three checks:
- Schema validation: ensures every notice is well-formed against ``notices.schema.json``
- Duplicate ID check: fails if any two notices share the same id
- URL reachability: ``HEAD-requests every action_param``, ``image``, and inline URL and fails if any are unreachable

2. auto-test-pr.yml — runs when a PR is opened or reopened against the release branch. It automatically creates a mirror PR targeting master with a [Test] prefix on the title, a link back to the original release PR, and the pre-filled /cloud command to configure a test server after merging.

3. Supporting files:
 - scripts/validate-schema.js — runs the AJV schema check
 - scripts/check-urls.js — URL reachability checker
 - scripts/check-duplicate-ids.js — duplicate ID detector