### PR TITLE
Upgrade GitHub Actions checkout and setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
-        node-version: '14'
+        persist-credentials: false
+
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      with:
+        node-version: '20'
     - run: npm install -g ajv-cli
     - run: ajv validate -s notices.schema.json -d notices.json | tee ajv-out.txt

--- a/.github/workflows/validate-notices.yml
+++ b/.github/workflows/validate-notices.yml
@@ -19,12 +19,13 @@ jobs:
  
     steps:
       - name: Checkout PR branch (with base branch history for diffing)
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0   # Full history so scripts can diff against base
- 
+
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '20'
           # No npm cache — there is no package-lock.json in this repo


### PR DESCRIPTION
#### Summary
Upgrade GitHub Actions checkout and setup-node
Also move CI schema validation onto Node 20 to match validate-notices and drop EOL Node 14.

#### Jira ticket
https://github.com/mattermost/notices/actions